### PR TITLE
Renewel Mechanism

### DIFF
--- a/includes/ApiInviteSignup.php
+++ b/includes/ApiInviteSignup.php
@@ -1,5 +1,4 @@
 <?php
-
 use MediaWiki\MediaWikiServices;
 
 class ApiInviteSignup extends ApiBase {
@@ -15,33 +14,115 @@ class ApiInviteSignup extends ApiBase {
 
         $email = $params['email'];
         $groups = array_filter(array_map('trim', explode(',', $params['groups'])));
-        $expiry = $params['expiry'] ?? null;
+        $expiry = $params['expiry'] ?? null;         // Expiry timestamp (YmdHis format expected)
+        $orderDate = $params['orderdate'] ?? null;  // Order date (YmdHis from Prestashop)
+        $targetGroup = 'paid'; // The target user group for renewal
+
+        $logFile = __DIR__ . '/invitesignup_api.log';
 
         if (!Sanitizer::validateEmail($email)) {
             $this->dieWithError('Invalid email address', 'bademail');
         }
 
-        // Use a system user as inviter
-        $user = User::newSystemUser('InviteBot', [ 'steal' => true ]);
+        // 1. Check InviteSignup DB for existing invitee for this email
         $store = new InviteStore(
             MediaWikiServices::getInstance()->getDBLoadBalancer()->getConnection(DB_PRIMARY),
             'invitesignup'
         );
-        $hash = $store->addInvite($user, $email, $groups, $expiry);
-        SpecialInviteSignup::sendInviteEmail($user, $email, $hash);
+        $inviteeId = $this->findInviteeIdByEmail($store, $email);
 
-        $this->getResult()->addValue(null, $this->getModuleName(), [ 'result' => 'success', 'hash' => $hash ]);
+        if (!$inviteeId) {
+            // No user exists for this email, send invite as before
+            $inviter = User::newSystemUser('InviteBot', [ 'steal' => true ]);
+            $hash = $store->addInvite($inviter, $email, $groups, $expiry);
+            SpecialInviteSignup::sendInviteEmail($inviter, $email, $hash);
+
+            file_put_contents($logFile, date('c') . " | $email | INVITE SENT | expiry: $expiry\n", FILE_APPEND);
+            $this->getResult()->addValue(null, $this->getModuleName(), [
+                'result' => 'invite_sent', 'hash' => $hash
+            ]);
+            return;
+        }
+
+        // 2. User exists: check current group membership and expiry
+        $user = User::newFromId($inviteeId);
+        $userGroupManager = MediaWikiServices::getInstance()->getUserGroupManager();
+        $currentGroups = $userGroupManager->getUserGroups($user);
+
+        // Fetch existing membership expiries using getUserGroupMemberships()
+        // This returns an array (group => UserGroupMembership object):contentReference[oaicite:2]{index=2}.
+        $memberships = $userGroupManager->getUserGroupMemberships($user);
+        $existingExpiry = null;
+        if (isset($memberships[$targetGroup])) {
+            // If user is in the group, get the expiry timestamp (YmdHis string or null)
+            $existingExpiry = $memberships[$targetGroup]->getExpiry();
+        }
+
+        $now = wfTimestampNow();
+        file_put_contents($logFile, date('c') . " | $email | EXISTING EXPIRY: $existingExpiry | NOW: $now | ORDERDATE: $orderDate | REQ EXPIRY: $expiry\n", FILE_APPEND);
+
+        // If user is not currently in group, or has no expiry set, or membership has expired
+        if (!in_array($targetGroup, $currentGroups) || !$existingExpiry || $existingExpiry < $now) {
+            // (Re-)add the user to the group with the new expiry from pswiki
+            // addUserToGroup will create or update the membership with the given expiry:contentReference[oaicite:3]{index=3}.
+            $userGroupManager->addUserToGroup($user, $targetGroup, $expiry);
+            file_put_contents($logFile, date('c') . " | $email | GROUP ADDED/RENEWED | expiry set to: $expiry\n", FILE_APPEND);
+            $this->getResult()->addValue(null, $this->getModuleName(), [
+                'result' => 'group_added_or_renewed', 'expiry' => $expiry
+            ]);
+            return;
+        }
+
+        // 3. User is in group and membership not expired: extend expiry by the renewal period
+        // Calculate period (in seconds) = (new expiry - order date)
+        if (!$orderDate) {
+            // If no order date provided, assume renewal starts now
+            $orderDate = $now;
+        }
+        $periodSeconds = wfTimestamp(TS_UNIX, $expiry) - wfTimestamp(TS_UNIX, $orderDate);
+
+        // Add the period to existing expiry
+        $existingExpiryUnix = wfTimestamp(TS_UNIX, $existingExpiry);
+        $newExpiryUnix = $existingExpiryUnix + $periodSeconds;
+        $newExpiry = wfTimestamp(TS_MW, $newExpiryUnix);
+
+        file_put_contents($logFile, date('c') . " | $email | EXTEND: existingExpiry: $existingExpiry | periodSeconds: $periodSeconds | newExpiry: $newExpiry\n", FILE_APPEND);
+
+        // Update the group expiry to the extended time
+        $userGroupManager->addUserToGroup($user, $targetGroup, $newExpiry);
+        $this->getResult()->addValue(null, $this->getModuleName(), [
+            'result'     => 'group_extended',
+            'old_expiry' => $existingExpiry,
+            'new_expiry' => $newExpiry
+        ]);
+    }
+
+    /**
+     * Find the user ID (invitee) for a given email from the InviteSignup DB.
+     * Returns user ID or null.
+     */
+    private function findInviteeIdByEmail($store, $email) {
+        $dbr = MediaWikiServices::getInstance()->getDBLoadBalancer()->getConnection(DB_REPLICA);
+        $table = $store->getTableName();
+        $row = $dbr->selectRow(
+            $table,
+            [ 'is_invitee' ],
+            [ 'is_email' => $email, 'is_invitee IS NOT NULL' ],
+            __METHOD__,
+            [ 'ORDER BY' => 'is_used DESC' ]
+        );
+        return $row && $row->is_invitee ? (int)$row->is_invitee : null;
     }
 
     public function getAllowedParams() {
         return [
-            'secret' => [ self::PARAM_TYPE => 'string', self::PARAM_REQUIRED => true ],
-            'email' => [ self::PARAM_TYPE => 'string', self::PARAM_REQUIRED => true ],
-            'groups' => [ self::PARAM_TYPE => 'string', self::PARAM_REQUIRED => true ],
-            'expiry' => [ self::PARAM_TYPE => 'string', self::PARAM_REQUIRED => false ],
+            'secret'    => [ self::PARAM_TYPE => 'string', self::PARAM_REQUIRED => true ],
+            'email'     => [ self::PARAM_TYPE => 'string', self::PARAM_REQUIRED => true ],
+            'groups'    => [ self::PARAM_TYPE => 'string', self::PARAM_REQUIRED => true ],
+            'expiry'    => [ self::PARAM_TYPE => 'string', self::PARAM_REQUIRED => false ],
+            'orderdate' => [ self::PARAM_TYPE => 'string', self::PARAM_REQUIRED => false ], // YmdHis
         ];
     }
-
     public function isWriteMode() {
         return true;
     }

--- a/includes/ApiInviteSignup.php
+++ b/includes/ApiInviteSignup.php
@@ -88,7 +88,9 @@ class ApiInviteSignup extends ApiBase {
 
         file_put_contents($logFile, date('c') . " | $email | EXTEND: existingExpiry: $existingExpiry | periodSeconds: $periodSeconds | newExpiry: $newExpiry\n", FILE_APPEND);
 
-        // Update the group expiry to the extended time
+        // **CHANGED**: Remove user from group before re-adding to apply new expiry
+        $userGroupManager->removeUserFromGroup($user, $targetGroup);
+        // Re-add user with the extended expiry timestamp
         $userGroupManager->addUserToGroup($user, $targetGroup, $newExpiry);
         $this->getResult()->addValue(null, $this->getModuleName(), [
             'result'     => 'group_extended',

--- a/includes/ApiInviteSignup.php
+++ b/includes/ApiInviteSignup.php
@@ -66,6 +66,7 @@ class ApiInviteSignup extends ApiBase {
             // (Re-)add the user to the group with the new expiry from pswiki
             // addUserToGroup will create or update the membership with the given expiry:contentReference[oaicite:3]{index=3}.
             $userGroupManager->addUserToGroup($user, $targetGroup, $expiry);
+            $store->updateExpiryByEmail($email, $expiry);
             file_put_contents($logFile, date('c') . " | $email | GROUP ADDED/RENEWED | expiry set to: $expiry\n", FILE_APPEND);
             $this->getResult()->addValue(null, $this->getModuleName(), [
                 'result' => 'group_added_or_renewed', 'expiry' => $expiry
@@ -92,6 +93,7 @@ class ApiInviteSignup extends ApiBase {
         $userGroupManager->removeUserFromGroup($user, $targetGroup);
         // Re-add user with the extended expiry timestamp
         $userGroupManager->addUserToGroup($user, $targetGroup, $newExpiry);
+        $store->updateExpiryByEmail($email, $newExpiry);
         $this->getResult()->addValue(null, $this->getModuleName(), [
             'result'     => 'group_extended',
             'old_expiry' => $existingExpiry,

--- a/includes/InviteStore.php
+++ b/includes/InviteStore.php
@@ -23,6 +23,10 @@ class InviteStore {
 		$this->db = $db;
 		$this->dbTable = $table;
 	}
+	
+	public function getTableName() {
+        return $this->dbTable;
+    }
 
 	public function getInvites() {
 		$fields = [ '*' ];

--- a/includes/InviteStore.php
+++ b/includes/InviteStore.php
@@ -24,6 +24,12 @@ class InviteStore {
 		$this->dbTable = $table;
 	}
 	
+	public function updateExpiryByEmail($email, $newExpiry) {
+		$conds = [ 'is_email' => $email, 'is_invitee IS NOT NULL' ];
+		$data = [ 'expiry' => $newExpiry ];
+		$this->db->update($this->dbTable, $data, $conds, __METHOD__);
+	}
+	
 	public function getTableName() {
         return $this->dbTable;
     }

--- a/includes/InviteStore.php
+++ b/includes/InviteStore.php
@@ -25,11 +25,11 @@ class InviteStore {
 	}
 	
 	public function updateExpiryByEmail($email, $newExpiry) {
-		$conds = [ 'is_email' => $email, 'is_invitee IS NOT NULL' ];
-		$data = [ 'expiry' => $newExpiry ];
-		$this->db->update($this->dbTable, $data, $conds, __METHOD__);
-	}
-	
+        $conds = [ 'is_email' => $email, 'is_invitee IS NOT NULL' ];
+        $data = [ 'expiry' => $newExpiry ];
+        $this->db->update($this->dbTable, $data, $conds, __METHOD__);
+    }
+
 	public function getTableName() {
         return $this->dbTable;
     }

--- a/version
+++ b/version
@@ -1,4 +1,0 @@
-InviteSignup: REL1_43
-2025-03-25T07:13:42
-
-aaea190


### PR DESCRIPTION
1. Sending Invite to new user.
2. Adding user to group after expiry with new expiry
3. Extending existing expiry if renewed before expiry.
------
1. Calculating the subscription period based on the expiry date provided by pswiki minus the order date.
2. Extending the group membership expiry by adding this period to the current expiry if the user is already in the group. [Removing and then re-adding]
3. Re-adding the user to the group with the expiry if their membership has already lapsed.